### PR TITLE
fix compilation error on melodic

### DIFF
--- a/crane_plus_ikfast_arm_plugin/package.xml
+++ b/crane_plus_ikfast_arm_plugin/package.xml
@@ -18,6 +18,7 @@
   <build_depend>roscpp</build_depend>
   <build_depend>tf_conversions</build_depend>
   <build_depend>pluginlib</build_depend>
+  <build_depend>liblapack-dev</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend>liblapack-dev</run_depend>

--- a/crane_plus_ikfast_arm_plugin/src/crane_plus_arm_ikfast_moveit_plugin.cpp
+++ b/crane_plus_ikfast_arm_plugin/src/crane_plus_arm_ikfast_moveit_plugin.cpp
@@ -357,12 +357,12 @@ bool IKFastKinematicsPlugin::initialize(const std::string &robot_description,
 
   ROS_DEBUG_STREAM_NAMED("ikfast","Reading joints and links from URDF");
 
-  boost::shared_ptr<urdf::Link> link = boost::const_pointer_cast<urdf::Link>(robot_model.getLink(getTipFrame()));
+  urdf::LinkConstSharedPtr link = robot_model.getLink(getTipFrame());
   while(link->name != base_frame_ && joint_names_.size() <= num_joints_)
   {
     ROS_DEBUG_NAMED("ikfast","Link %s",link->name.c_str());
     link_names_.push_back(link->name);
-    boost::shared_ptr<urdf::Joint> joint = link->parent_joint;
+    urdf::JointSharedPtr joint = link->parent_joint;
     if(joint)
     {
       if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)


### PR DESCRIPTION
The crane_plus_ikfast_arm_plugin package couldn't build in melodic.
By referring to [this issue](https://github.com/ros-industrial/staubli/pull/30/files) we have successfully built this package in melodic.

I wanted to create a melodic-devel in the original repository too but only found the master branch.

I am still new to the git hub system so I apologize for any inconveniences that may happen.